### PR TITLE
Increase RsaLowerLength from 1024 to 4096 bits

### DIFF
--- a/create_private_key.go
+++ b/create_private_key.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Lower boundary limit for RSA private keys
-	RsaLowerLength = 1024
+	RsaLowerLength = 4096
 	// Upper boundary limit for RSA private keys
 	RsaUpperLength = 65536
 )


### PR DESCRIPTION
RSA 1024 bits is not save for use. [Firefox dropped support in 2014](https://blog.mozilla.org/security/2014/09/08/phasing-out-certificates-with-1024-bit-rsa-keys/). 2048 is the accepted standard, but 4096 is already used by certificate authorities like [Let's Encrypt](https://letsencrypt.org/docs/integration-guide/#supported-key-algorithms).